### PR TITLE
Proper  "Java is not installed inside the repository" error  handling

### DIFF
--- a/poc.py
+++ b/poc.py
@@ -83,11 +83,14 @@ def payload(userip: str, webport: int, lport: int) -> None:
 
 
 def check_java() -> bool:
-    exit_code = subprocess.call([
+    try:
+        subprocess.call([
         os.path.join(CUR_FOLDER, 'jdk1.8.0_20/bin/java'),
         '-version',
     ], stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
-    return exit_code == 0
+        return 1
+    except:
+        return 0
 
 
 def ldap_server(userip: str, lport: int) -> None:


### PR DESCRIPTION
Hey, while experimenting a bit with the script i noticed that the "Java is not installed inside the repository " error is never thrown. Even if it's really not installed inside the repository, it will just [yell at you and exit](https://imgur.com/a/aym8CbK), i fixed it so it actually [throws the error instead](https://imgur.com/sdFUqMo.png) .

Thanks for reading my pull request and feel free to close it or comment if something is wrong.